### PR TITLE
Fixed bad copy & paste for account lookup

### DIFF
--- a/app/helpers/authentication_helper.js
+++ b/app/helpers/authentication_helper.js
@@ -6,7 +6,7 @@ const db = require(path.resolve(__dirname, '../models'));
 module.exports = {
   authenticate: function(email, password) {
     return new Promise((resolve, reject) => {
-      db.model('user').findOne({ where: { email }}).then((user) => {
+      db.model('user').findOne({ where: { email: email } }).then((user) => {
         if (user && user.passwordSalt && user.passwordHash) {
           const hash = crypto.createHash('sha512');
           hash.update(password);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -46,7 +46,7 @@ router.get('/history', function(req, res) {
 
 router.get('/history/:accountId', function(req, res) {
   req.app.locals.db.model('account').findOne({
-    _id: req.params.accountId,
+    where: { _id: req.params.accountId },
     include: [{ model: req.app.locals.db.model('transaction') }],
   }).then((account) => {
     res.render('account_history', {
@@ -76,7 +76,7 @@ router.get('/deposit', function(req, res) {
 
 router.post('/deposit', function(req, res) {
   req.app.locals.db.model('account').findOne({
-    _id: req.params.accountId,
+    where: { _id: req.body.account },
     include: [{ model: req.app.locals.db.model('transaction') }],
   }).then((account) => {
     req.app.locals.db.model('transaction').create({
@@ -112,7 +112,7 @@ router.get('/withdraw', function(req, res) {
 
 router.post('/withdraw', function(req, res) {
   req.app.locals.db.model('account').findOne({
-    _id: req.params.accountId,
+    where: { _id: req.body.account },
     include: [{ model: req.app.locals.db.model('transaction') }],
   }).then((account) => {
     req.app.locals.db.model('transaction').create({
@@ -127,7 +127,6 @@ router.post('/withdraw', function(req, res) {
     });
   });
 });
-
 
 /* login form */
 router.get('/login', function(req, res) {


### PR DESCRIPTION
The code for account lookup when doing account history, deposits and withdrawals was always returning the first account.